### PR TITLE
Allow multiple static Component Presentations

### DIFF
--- a/dotnet/DD4T.Mvc/Html/DefaultComponentPresentationRenderer.cs
+++ b/dotnet/DD4T.Mvc/Html/DefaultComponentPresentationRenderer.cs
@@ -43,16 +43,18 @@ namespace DD4T.Mvc.Html
                 // In that case, we simply write it out
                 // Note that this type of component presentations cannot be excluded based on schema, because we do not know the schema
                 if (!string.IsNullOrEmpty(cp.RenderedContent))
-                    return new MvcHtmlString(cp.RenderedContent);
-                LoggerService.Debug("rendering cp {0} - {1}", LoggingCategory.Performance, cp.Component.Id, cp.ComponentTemplate.Id);
-               
-                cp.Page = tridionPage;
-                LoggerService.Debug("about to call RenderComponentPresentation", LoggingCategory.Performance);
-                if (ShowAnchors)
-                    sb.Append(string.Format("<a id=\"{0}\"></a>", DD4T.Utils.TridionHelper.GetLocalAnchor(cp)));
-                sb.Append(RenderComponentPresentation(cp, htmlHelper));
-                LoggerService.Debug("finished calling RenderComponentPresentation", LoggingCategory.Performance);
+                    sb.Append(cp.RenderedContent);
+                else
+                {
+                    LoggerService.Debug("rendering cp {0} - {1}", LoggingCategory.Performance, cp.Component.Id, cp.ComponentTemplate.Id);
 
+                    cp.Page = tridionPage;
+                    LoggerService.Debug("about to call RenderComponentPresentation", LoggingCategory.Performance);
+                    if (ShowAnchors)
+                        sb.Append(string.Format("<a id=\"{0}\"></a>", DD4T.Utils.TridionHelper.GetLocalAnchor(cp)));
+                    sb.Append(RenderComponentPresentation(cp, htmlHelper));
+                    LoggerService.Debug("finished calling RenderComponentPresentation", LoggingCategory.Performance);
+                }
             }
             LoggerService.Information("<<ComponentPresentations", LoggingCategory.Performance);
             return MvcHtmlString.Create(sb.ToString());


### PR DESCRIPTION
At the moment, if any static (classic) Component Presentations are included in the page, they are the only ones which appear. This is because of the "return" if RenderedContent has a value.

Updated the code to rather than return, append the static (classic) Component Presentation to the page as per any other dynamic (DD4T) one
