### PR TITLE
Keyword.MetadataSchema property not output to DD4T XML.

### DIFF
--- a/dotnet/DD4T.Templates.Base/Builder/BuildManager.cs
+++ b/dotnet/DD4T.Templates.Base/Builder/BuildManager.cs
@@ -27,14 +27,14 @@ namespace DD4T.Templates.Base.Builder
             return PageBuilder.BuildPage(tcmPage, engine, this, linkLevels, resolveWidthAndHeight, publishEmptyFields);
         }
 
-        public virtual List<Dynamic.Category> BuildCategories(TComm.Page page)
+        public virtual List<Dynamic.Category> BuildCategories(TComm.Page page, int linkLevels, bool resolveWidthAndHeight, bool publishEmptyFields)
         {
-            return CategoriesBuilder.BuildCategories(page,this);
+            return CategoriesBuilder.BuildCategories(page, linkLevels, resolveWidthAndHeight, publishEmptyFields, this);
         }
 
-        public virtual List<Dynamic.Category> BuildCategories(TCM.Component component)
+        public virtual List<Dynamic.Category> BuildCategories(TCM.Component component, int linkLevels, bool resolveWidthAndHeight, bool publishEmptyFields)
         {
-            return CategoriesBuilder.BuildCategories(component, this);
+            return CategoriesBuilder.BuildCategories(component, linkLevels, resolveWidthAndHeight, publishEmptyFields, this);
         }
 
         public virtual Dynamic.Component BuildComponent(TCM.Component tcmComponent)
@@ -67,9 +67,9 @@ namespace DD4T.Templates.Base.Builder
             return FieldsBuilder.BuildFields(tcmItemFields, linkLevels, resolveWidthAndHeight,publishEmptyFields, this);
         }
 
-        public Dynamic.Keyword BuildKeyword(TCM.Keyword keyword)
+        public Dynamic.Keyword BuildKeyword(TCM.Keyword keyword, int linkLevels, bool resolveWidthAndHeight, bool publishEmptyFields)
         {
-            return KeywordBuilder.BuildKeyword(keyword);
+            return KeywordBuilder.BuildKeyword(keyword, linkLevels, resolveWidthAndHeight, publishEmptyFields, this);
         }
 
         public virtual Dynamic.OrganizationalItem BuildOrganizationalItem(TComm.StructureGroup tcmStructureGroup)

--- a/dotnet/DD4T.Templates.Base/Builder/CategoriesBuilder.cs
+++ b/dotnet/DD4T.Templates.Base/Builder/CategoriesBuilder.cs
@@ -11,7 +11,7 @@ namespace DD4T.Templates.Base.Builder
 {
     public class CategoriesBuilder
     {
-        public static List<Dynamic.Category> BuildCategories(TComm.Page page, BuildManager manager)
+        public static List<Dynamic.Category> BuildCategories(TComm.Page page, int linkLevels, bool resolveWidthAndHeight, bool publishEmptyFields, BuildManager manager)
         {
             // note that there might be multiple fields based on the same category, so we need to combine them
             // for that purpose we use a dictionary
@@ -27,7 +27,7 @@ namespace DD4T.Templates.Base.Builder
 
             // first, add categires from the metadata
             ItemFields tcmMetadataFields = new TCM.Fields.ItemFields(page.Metadata, page.MetadataSchema);
-            addFromItemFields(tcmMetadataFields, categories, manager);
+            addFromItemFields(tcmMetadataFields, categories, linkLevels, resolveWidthAndHeight, publishEmptyFields, manager);
 
             // finally, create a List from the Dictionary and return it
             List<Dynamic.Category> categoryList = new List<Dynamic.Category>();
@@ -38,7 +38,7 @@ namespace DD4T.Templates.Base.Builder
             return categoryList;
         }
 
-        public static List<Dynamic.Category> BuildCategories(TCM.Component component, BuildManager manager)
+        public static List<Dynamic.Category> BuildCategories(TCM.Component component, int linkLevels, bool resolveWidthAndHeight,bool publishEmptyFields, BuildManager manager)
         {
             // note that there might be multiple fields based on the same category, so we need to combine them
             // for that purpose we use a dictionary
@@ -52,7 +52,7 @@ namespace DD4T.Templates.Base.Builder
                 GeneralUtils.TimedLog("finished creating tcm ItemFields from Content");
                 GeneralUtils.TimedLog("start converting content ItemFields to dynamic fields");
 
-                addFromItemFields(tcmFields, categories, manager);
+                addFromItemFields(tcmFields, categories, linkLevels,  resolveWidthAndHeight, publishEmptyFields, manager);
                 GeneralUtils.TimedLog("finished converting content ItemFields to dynamic fields");
             }
 
@@ -63,7 +63,7 @@ namespace DD4T.Templates.Base.Builder
                 ItemFields tcmMetadataFields = new TCM.Fields.ItemFields(component.Metadata, component.MetadataSchema);
                 GeneralUtils.TimedLog("finished creating tcm ItemFields from Metadata");
                 GeneralUtils.TimedLog("start converting metadata ItemFields to dynamic fields");
-                addFromItemFields(tcmMetadataFields, categories, manager);
+                addFromItemFields(tcmMetadataFields, categories, linkLevels, resolveWidthAndHeight, publishEmptyFields, manager);
                 GeneralUtils.TimedLog("finished converting metadata ItemFields to dynamic fields");
             }
 
@@ -76,7 +76,7 @@ namespace DD4T.Templates.Base.Builder
             return categoryList;
         }
 
-        private static void addFromItemFields(ItemFields tcmFields, Dictionary<string, Dynamic.Category> categories, BuildManager manager)
+        private static void addFromItemFields(ItemFields tcmFields, Dictionary<string, Dynamic.Category> categories, int linkLevels, bool resolveWidthAndHeight,bool publishEmptyFields, BuildManager manager)
         {
             foreach (ItemField f in tcmFields)
             {
@@ -110,7 +110,7 @@ namespace DD4T.Templates.Base.Builder
                         }
                         if (!alreadyThere)
                         {
-                            dc.Keywords.Add(manager.BuildKeyword(keyword));
+                            dc.Keywords.Add(manager.BuildKeyword(keyword, linkLevels, resolveWidthAndHeight, publishEmptyFields));
                         }
                     }
                 }
@@ -156,7 +156,7 @@ namespace DD4T.Templates.Base.Builder
                                         }
                                         if (!alreadyThere)
                                         {
-                                            dc.Keywords.Add(manager.BuildKeyword(keyword));
+                                            dc.Keywords.Add(manager.BuildKeyword(keyword, linkLevels, resolveWidthAndHeight, publishEmptyFields));
                                         }
                                     }
                                 }

--- a/dotnet/DD4T.Templates.Base/Builder/ComponentBuilder.cs
+++ b/dotnet/DD4T.Templates.Base/Builder/ComponentBuilder.cs
@@ -108,7 +108,7 @@ namespace DD4T.Templates.Base.Builder
           c.OwningPublication = manager.BuildPublication(tcmComponent.OwningRepository);
           TCM.Folder folder = (TCM.Folder)tcmComponent.OrganizationalItem;
           c.Folder = manager.BuildOrganizationalItem(folder);
-          c.Categories = manager.BuildCategories(tcmComponent);
+          c.Categories = manager.BuildCategories(tcmComponent, linkLevels, resolveWidthAndHeight, publishEmptyFields);
 
           manager.AddXpathToFields(c.Fields, "tcm:Content/custom:" + tcmComponent.Schema.RootElementName); // TODO: check if the first part of the XPath is really the root element name, or simply always 'Content'
           manager.AddXpathToFields(c.MetadataFields, "tcm:Metadata/custom:Metadata");

--- a/dotnet/DD4T.Templates.Base/Builder/FieldBuilder.cs
+++ b/dotnet/DD4T.Templates.Base/Builder/FieldBuilder.cs
@@ -128,7 +128,7 @@ namespace DD4T.Templates.Base.Builder
                     {
                         // todo: add binary to package, and add BinaryUrl property to the component
                         f.Values.Add(kw.Title);
-                        f.Keywords.Add(manager.BuildKeyword(kw));
+                        f.Keywords.Add(manager.BuildKeyword(kw, linkLevels - 1, resolveWidthAndHeight, publishEmptyFields));
                     }
                     
                     KeywordFieldDefinition fieldDef = (KeywordFieldDefinition)sField.Definition;

--- a/dotnet/DD4T.Templates.Base/Builder/FieldsBuilder.cs
+++ b/dotnet/DD4T.Templates.Base/Builder/FieldsBuilder.cs
@@ -66,6 +66,25 @@ namespace DD4T.Templates.Base.Builder
                                        }
                                    }
                                    break;
+                               case FieldType.Keyword:
+                                   foreach (Keyword keyword in f.Keywords)
+                                   {
+                                       bool valueExists = false;
+                                       foreach (Keyword existingKeywords in existingField.Keywords)
+                                       {
+                                           if (keyword.Id.Equals(existingKeywords.Id))
+                                           {
+                                               // this value already exists
+                                               valueExists = true;
+                                               break;
+                                           }
+                                       }
+                                       if (!valueExists)
+                                       {
+                                           existingField.Keywords.Add(keyword);
+                                       }
+                                   }
+                                   break;
                                case FieldType.Date:
                                    foreach (DateTime dateTime in f.DateTimeValues)
                                    {

--- a/dotnet/DD4T.Templates.Base/Builder/KeywordBuilder.cs
+++ b/dotnet/DD4T.Templates.Base/Builder/KeywordBuilder.cs
@@ -5,8 +5,18 @@ using Tridion.ContentManager.ContentManagement;
 namespace DD4T.Templates.Base.Builder
 {
    public class KeywordBuilder
-   {
-      public static Dynamic.Keyword BuildKeyword(Keyword keyword)
+   {       
+       public static Dynamic.Keyword BuildKeyword(Keyword keyword)
+       {
+           return BuildKeyword(keyword, 0, false, false, null);
+       }
+
+       public static Dynamic.Keyword BuildKeyword(Keyword keyword, int linkLevels, bool resolveWidthAndHeight, bool publishEmptyFields)
+       {
+           return BuildKeyword(keyword, linkLevels, resolveWidthAndHeight, publishEmptyFields, null);
+       }
+
+      public static Dynamic.Keyword BuildKeyword(Keyword keyword, int linkLevels, bool resolveWidthAndHeight, bool publishEmptyFields, BuildManager manager)
       {
          Dynamic.Keyword dk = new Dynamic.Keyword();
          dk.Id = keyword.Id;
@@ -15,6 +25,16 @@ namespace DD4T.Templates.Base.Builder
          dk.Description = keyword.Description;
          dk.Key = keyword.Key;
          dk.TaxonomyId = keyword.OrganizationalItem.Id;
+
+         if (keyword.MetadataSchema != null)
+         {
+             if (manager != null)
+             {
+                 var tcmFields = new Tridion.ContentManager.ContentManagement.Fields.ItemFields(keyword.Metadata, keyword.MetadataSchema);
+                 dk.MetadataFields = manager.BuildFields(tcmFields, linkLevels, resolveWidthAndHeight, publishEmptyFields);
+             }
+         }
+
          return dk;
       }
       private static string FindKeywordPath(Keyword keyword)

--- a/dotnet/DD4T.Templates.Base/Builder/PageBuilder.cs
+++ b/dotnet/DD4T.Templates.Base/Builder/PageBuilder.cs
@@ -53,7 +53,7 @@ namespace DD4T.Templates.Base.Builder
             p.StructureGroup = manager.BuildOrganizationalItem((TCM.StructureGroup)tcmPage.OrganizationalItem);
             p.Publication = manager.BuildPublication(tcmPage.ContextRepository);
             p.OwningPublication = manager.BuildPublication(tcmPage.OwningRepository);
-            p.Categories = manager.BuildCategories(tcmPage);
+            p.Categories = manager.BuildCategories(tcmPage, linkLevels, resolveWidthAndHeight, publishEmptyFields);
 
             manager.AddXpathToFields(p.MetadataFields, "Metadata");
 


### PR DESCRIPTION
Keyword has MetadataSchema property but the KeywordBuilder is not populating it - this leaves keyword metadata fields not part of the final DD4T XML.

Updating had a knock effect to categories (obviously).
