### PR TITLE
Publishing Binaries from Text Field

### DIFF
--- a/dotnet/DD4T.Templates.Base/Utils/BinaryPublisher.cs
+++ b/dotnet/DD4T.Templates.Base/Utils/BinaryPublisher.cs
@@ -83,7 +83,7 @@ namespace DD4T.Templates.Base.Utils
                     log.Debug("about to publish binary with uri " + link.Value);
                     string path = PublishMultimediaComponent(link.Value);
                     log.Debug("binary will be published to path " + path);
-                    img.SetAttribute("src", path);
+                    img.SetAttribute("href", path);
                 }
                 else
                 {


### PR DESCRIPTION
Binaries referenced as a link in a rich text field don't get published. Amended so that the a tag uses href not src
