### PR TITLE
Release 1.31

### DIFF
--- a/java/dd4t-api/src/main/java/org/dd4t/core/caching/Cachable.java
+++ b/java/dd4t-api/src/main/java/org/dd4t/core/caching/Cachable.java
@@ -15,6 +15,8 @@
  */
 package org.dd4t.core.caching;
 
+import java.io.Serializable;
+
 /**
  * Interface any object Cachable by the CacheAgent class must implement.
  * Its functions are used as such:
@@ -25,7 +27,7 @@ package org.dd4t.core.caching;
  * @author Rogier Oudshoorn, Capgemini
  *
  */
-public interface Cachable {
+public interface Cachable extends Serializable {
 	public void notifyCached(String key, String realm);
 	
 	public String getCacheRealm();

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/BaseComponent.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/BaseComponent.java
@@ -21,6 +21,7 @@ import org.simpleframework.xml.Element;
 
 public class BaseComponent extends BasePublishedItem {
 
+	private static final long serialVersionUID = -4623513264018771914L;
 	@Element(name = "schema")
 	private Schema schema;
 	private String resolvedUrl;

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/BaseField.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/BaseField.java
@@ -15,6 +15,7 @@
  */
 package org.dd4t.contentmodel.impl;
 
+import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -27,7 +28,8 @@ import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
 
 
-public abstract class BaseField implements Field {
+public abstract class BaseField implements Field, Serializable {
+	private static final long serialVersionUID = -4453264042325014679L;
 	@Element(name = "name")
 	private String name;
 	@ElementList(name = "textValues", required = false)

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/BaseItem.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/BaseItem.java
@@ -15,6 +15,7 @@
  */
 package org.dd4t.contentmodel.impl;
 
+import java.io.Serializable;
 import java.util.HashMap;
 
 import org.dd4t.contentmodel.Item;
@@ -27,8 +28,9 @@ import org.simpleframework.xml.Element;
  * @author Quirijn Slings
  * 
  */
-public abstract class BaseItem implements Item {
+public abstract class BaseItem implements Item, Serializable {
 
+	private static final long serialVersionUID = 8259063559927307354L;
 	@Element(name = "id")
 	private String id;
 	@Element(name = "title")

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/BasePage.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/BasePage.java
@@ -21,6 +21,7 @@ import org.simpleframework.xml.Element;
 
 public abstract class BasePage extends BasePublishedItem {
 
+	private static final long serialVersionUID = -6291418501535850012L;
 	@Element(name = "schema", required = false)
 	protected Schema schema;
 

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/BasePublishedItem.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/BasePublishedItem.java
@@ -30,6 +30,7 @@ import org.dd4t.contentmodel.impl.BaseRepositoryLocalItem;;
  */
 public abstract class BasePublishedItem extends BaseRepositoryLocalItem implements PublishedItem, Cachable, ObjectSizeProvider {
 
+	private static final long serialVersionUID = 2996230175958122285L;
 	private String source;
 	private ItemMeta nativeMetadata;
 	private int objectSize;

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/BaseRepositoryLocalItem.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/BaseRepositoryLocalItem.java
@@ -30,6 +30,8 @@ import org.simpleframework.xml.Element;
 public abstract class BaseRepositoryLocalItem extends BaseItem implements
 		RepositoryLocalItem {
 
+	private static final long serialVersionUID = 5662071841155997330L;
+
 	@Element(name = "publication", required = false)
 	private Publication publication;
 

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/CategoryImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/CategoryImpl.java
@@ -25,7 +25,7 @@ import org.simpleframework.xml.ElementList;
 
 public class CategoryImpl extends BaseItem implements Category {
 
-
+	private static final long serialVersionUID = -6425683149215945484L;
 	@ElementList(name = "keywords", required = false, type = KeywordImpl.class)
 	private List<KeywordImpl> keywords;
 	

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/ComponentLinkField.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/ComponentLinkField.java
@@ -24,6 +24,8 @@ import org.dd4t.contentmodel.Field;
 
 public class ComponentLinkField extends BaseField implements Field {
 
+	private static final long serialVersionUID = 8921183912167079373L;
+
 	public ComponentLinkField() {
 		setFieldType(FieldType.ComponentLink);
 	}

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/ComponentPresentationImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/ComponentPresentationImpl.java
@@ -15,6 +15,8 @@
  */
 package org.dd4t.contentmodel.impl;
 
+import java.io.Serializable;
+
 import org.dd4t.contentmodel.ComponentPresentation;
 import org.dd4t.contentmodel.ComponentTemplate;
 import org.dd4t.contentmodel.GenericComponent;
@@ -27,7 +29,8 @@ import org.simpleframework.xml.Element;
  * @author bjornl
  * 
  */
-public class ComponentPresentationImpl implements ComponentPresentation {
+public class ComponentPresentationImpl implements ComponentPresentation, Serializable {
+	private static final long serialVersionUID = 8065995208403161518L;
 	@Element(name = "component", required = false)
 	private GenericComponent component;
 	@Element(name = "componentTemplate", required = false)

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/ComponentTemplateImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/ComponentTemplateImpl.java
@@ -27,6 +27,7 @@ import org.simpleframework.xml.ElementMap;
 
 public class ComponentTemplateImpl extends BaseRepositoryLocalItem implements ComponentTemplate {
 	
+	private static final long serialVersionUID = 9021348274530100412L;
 	@Element(name = "outputFormat", required = false)
 	private String outputFormat;
 	@ElementMap(name = "metadata", keyType = String.class, valueType = Field.class, entry = "item", required = false)

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/DateField.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/DateField.java
@@ -24,6 +24,8 @@ import org.dd4t.core.util.DateUtils;
 
 public class DateField extends BaseField implements Field {
 
+	private static final long serialVersionUID = 6929517321834738759L;
+
 	public DateField(){
 		setFieldType(FieldType.Date);
 	}

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/DynamicComponentImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/DynamicComponentImpl.java
@@ -6,6 +6,7 @@ import com.tridion.dcp.ComponentPresentation;
 
 public class DynamicComponentImpl extends GenericComponentImpl implements DynamicComponent
 {
+	private static final long serialVersionUID = 9021378235490500412L;
 	private ComponentPresentation nativeDCP;
 
 	public void setNativeDCP(ComponentPresentation nativeDCP){

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/EmbeddedField.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/EmbeddedField.java
@@ -24,6 +24,8 @@ import org.dd4t.contentmodel.FieldSet;
 
 public class EmbeddedField extends BaseField implements Field {
 
+	private static final long serialVersionUID = -4144685499099187584L;
+
 	public EmbeddedField(){
 		setFieldType(FieldType.Embedded);
 	}

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/FieldSetImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/FieldSetImpl.java
@@ -15,6 +15,7 @@
  */
 package org.dd4t.contentmodel.impl;
 
+import java.io.Serializable;
 import java.util.Map;
 
 import org.dd4t.contentmodel.Field;
@@ -24,8 +25,10 @@ import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementMap;
 
 
-public class FieldSetImpl implements FieldSet {
-    @ElementMap(name = "fields", keyType = String.class, valueType = Field.class, entry = "item", required = false)
+public class FieldSetImpl implements FieldSet, Serializable {
+	private static final long serialVersionUID = -7728755743007304678L;
+
+	@ElementMap(name = "fields", keyType = String.class, valueType = Field.class, entry = "item", required = false)
     private Map<String, Field> content;
     
     @Element(name = "schema", required = true)

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/GenericComponentImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/GenericComponentImpl.java
@@ -15,6 +15,7 @@
  */
 package org.dd4t.contentmodel.impl;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -34,8 +35,9 @@ import org.simpleframework.xml.ElementMap;
 
 
 public class GenericComponentImpl extends BaseComponent implements
-		GenericComponent, HasContent, HasMetadata, HasMultimedia {
+		GenericComponent, HasContent, HasMetadata, HasMultimedia, Serializable {
 
+	private static final long serialVersionUID = 6524240883792107394L;
 	@ElementMap(name = "metadata", keyType = String.class, valueType = Field.class, entry = "item", required = false)
 	private Map<String, Field> metadata;
 	@ElementMap(name = "fields", keyType = String.class, valueType = Field.class, entry = "item", required = false)

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/GenericComponentImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/GenericComponentImpl.java
@@ -15,7 +15,6 @@
  */
 package org.dd4t.contentmodel.impl;
 
-import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -35,9 +34,9 @@ import org.simpleframework.xml.ElementMap;
 
 
 public class GenericComponentImpl extends BaseComponent implements
-		GenericComponent, HasContent, HasMetadata, HasMultimedia, Serializable {
+		GenericComponent, HasContent, HasMetadata, HasMultimedia {
 
-	private static final long serialVersionUID = 6524240883792107394L;
+	private static final long serialVersionUID = 6589629775492497736L;
 	@ElementMap(name = "metadata", keyType = String.class, valueType = Field.class, entry = "item", required = false)
 	private Map<String, Field> metadata;
 	@ElementMap(name = "fields", keyType = String.class, valueType = Field.class, entry = "item", required = false)

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/GenericPageImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/GenericPageImpl.java
@@ -15,6 +15,7 @@
  */
 package org.dd4t.contentmodel.impl;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +36,9 @@ import org.simpleframework.xml.Root;
 
 
 @Root(name = "page")
-public class GenericPageImpl extends BasePage implements GenericPage, HasMetadata {
+public class GenericPageImpl extends BasePage implements GenericPage, HasMetadata, Serializable {
+
+	private static final long serialVersionUID = -4888166753098796796L;
 
 	@ElementMap(name = "metadata", keyType = String.class, valueType = Field.class, entry = "item", required = false)
 	private Map<String, Field> metadata;

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/GenericPageImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/GenericPageImpl.java
@@ -15,7 +15,6 @@
  */
 package org.dd4t.contentmodel.impl;
 
-import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -36,9 +35,7 @@ import org.simpleframework.xml.Root;
 
 
 @Root(name = "page")
-public class GenericPageImpl extends BasePage implements GenericPage, HasMetadata, Serializable {
-
-	private static final long serialVersionUID = -4888166753098796796L;
+public class GenericPageImpl extends BasePage implements GenericPage, HasMetadata {
 
 	@ElementMap(name = "metadata", keyType = String.class, valueType = Field.class, entry = "item", required = false)
 	private Map<String, Field> metadata;

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/KeywordImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/KeywordImpl.java
@@ -26,6 +26,8 @@ import org.simpleframework.xml.ElementMap;
 
 
 public class KeywordImpl extends BaseItem implements Keyword, HasMetadata {
+	private static final long serialVersionUID = 8762935962487695238L;
+
 	@Attribute(name = "key", required = false)
 	private String key;
 

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/MultimediaImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/MultimediaImpl.java
@@ -15,13 +15,16 @@
  */
 package org.dd4t.contentmodel.impl;
 
+import java.io.Serializable;
+
 import org.dd4t.contentmodel.Multimedia;
 import org.simpleframework.xml.Element;
 
 import com.tridion.data.BinaryData;
 
-public class MultimediaImpl implements Multimedia {
+public class MultimediaImpl implements Multimedia, Serializable {
 
+	private static final long serialVersionUID = 1804178250500823921L;
 	private BinaryData binaryData;
 	@Element(name = "height", required = false)
 	private int height;

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/NumericField.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/NumericField.java
@@ -23,6 +23,8 @@ import org.dd4t.contentmodel.Field;
 
 public class NumericField extends BaseField implements Field {
 
+	private static final long serialVersionUID = -8138417213590528773L;
+
 	public NumericField(){
 		setFieldType(FieldType.Number);
 	}

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/OrganizationalItemImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/OrganizationalItemImpl.java
@@ -22,6 +22,7 @@ import org.simpleframework.xml.Element;
 public class OrganizationalItemImpl extends BaseItem implements
 		OrganizationalItem {
 
+	private static final long serialVersionUID = 8331589268695218999L;
 	@Element(name = "publicationId")
 	private String publicationId;
 

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/PageTemplateImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/PageTemplateImpl.java
@@ -29,6 +29,7 @@ import org.simpleframework.xml.ElementMap;
 public class PageTemplateImpl extends BaseRepositoryLocalItem implements
 		PageTemplate, HasMetadata {
 
+	private static final long serialVersionUID = 827151524534020212L;
 	@Element(name = "fileExtension")
 	private String fileExtension;
 	@ElementMap(name = "metadata", keyType = String.class, valueType = Field.class, entry = "item", required = false)

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/PublicationImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/PublicationImpl.java
@@ -19,6 +19,8 @@ import org.dd4t.contentmodel.Publication;
 
 public class PublicationImpl extends BaseItem implements Publication {
 
+	private static final long serialVersionUID = -4288636619154135599L;
+
 	public PublicationImpl(){
 		super();
 	}

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/SchemaImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/SchemaImpl.java
@@ -20,7 +20,8 @@ import org.simpleframework.xml.Element;
 
 
 public class SchemaImpl extends BaseRepositoryLocalItem implements Schema {
-    @Element(name = "rootElement", required = false)
+	private static final long serialVersionUID = 1113470472825303735L;
+	@Element(name = "rootElement", required = false)
     private String rootElement;
 
     public String getRootElement() {

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/SimpleBinaryImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/SimpleBinaryImpl.java
@@ -24,6 +24,7 @@ import com.tridion.storage.BinaryMeta;
 
 public class SimpleBinaryImpl extends BasePublishedItem implements SimpleBinary {
 
+	private static final long serialVersionUID = 8989764444969980602L;
 	private BinaryData binaryData = null;
 	private BinaryMeta nativeBinaryMetaData = null;
 	private BinaryFactory factory;

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/SimpleComponentImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/SimpleComponentImpl.java
@@ -22,6 +22,8 @@ import org.dd4t.contentmodel.SimpleComponent;
 
 public class SimpleComponentImpl extends BaseComponent implements SimpleComponent {
 
+	private static final long serialVersionUID = -3488271516919038033L;
+
 	@Override
 	public Date getLastPublishedDate() {
 		// TODO Auto-generated method stub

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/SimplePageImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/SimplePageImpl.java
@@ -22,6 +22,8 @@ import org.dd4t.contentmodel.SimplePage;
 
 public class SimplePageImpl extends BasePage implements SimplePage {
 
+	private static final long serialVersionUID = 6797658005502610107L;
+
 	@Override
 	public Date getLastPublishedDate() {
 		// TODO Auto-generated method stub

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/StructureGroupImpl.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/StructureGroupImpl.java
@@ -21,6 +21,7 @@ import org.simpleframework.xml.Element;
 
 public class StructureGroupImpl extends BaseItem implements StructureGroup {
 
+	private static final long serialVersionUID = 1498020047755587604L;
 	@Element(name = "publicationId")
 	private String publicationId;
 

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/TextField.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/TextField.java
@@ -23,6 +23,7 @@ import org.simpleframework.xml.Attribute;
 
 
 public class TextField extends BaseField implements Field {
+	private static final long serialVersionUID = -4016701399160459282L;
 	@Attribute(required = false)
 	private String categoryId;
 	@Attribute(required = false)

--- a/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/XhtmlField.java
+++ b/java/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/XhtmlField.java
@@ -19,6 +19,8 @@ import org.dd4t.contentmodel.Field;
 
 public class XhtmlField extends TextField implements Field {
 
+	private static final long serialVersionUID = -926939626186930607L;
+
 	public XhtmlField(){
 		setFieldType(FieldType.Xhtml);
 	}


### PR DESCRIPTION
This pull request contains three commits that make the main DD4T object model Serializable. The benefit of this is that it enables these objects to be cached in a persistent store via Ehcache. Currently these objects can be cached in memory via Ehcache, but they cannot be held in persistent cache since they are not Serializable.