### PR TITLE
Issue-16: RenderComponentPresentationsByView should work without metadata

### DIFF
--- a/dotnet/DD4T.Mvc/Controllers/TridionControllerBase.cs
+++ b/dotnet/DD4T.Mvc/Controllers/TridionControllerBase.cs
@@ -59,18 +59,11 @@ namespace DD4T.Mvc.Controllers
 
         protected virtual ViewResult GetView(IComponentPresentation componentPresentation)
         {
-            string viewName = null;
-            if (componentPresentation.ComponentTemplate.MetadataFields == null || !componentPresentation.ComponentTemplate.MetadataFields.ContainsKey("view"))
-                viewName = componentPresentation.ComponentTemplate.Title.Replace(" ", "");
-            else
-                viewName = componentPresentation.ComponentTemplate.MetadataFields["view"].Value; 
+            if (ComponentPresentationRenderer == null)
+                throw new ConfigurationException("No ComponentPresentationRenderer configured");
 
-            if (string.IsNullOrEmpty(viewName))
-            {
-                throw new ConfigurationException("no view configured for component template " + componentPresentation.ComponentTemplate.Id);
-            }
+            string viewName = componentPresentationRenderer.GetComponentTemplateView(componentPresentation.ComponentTemplate);
             return View(viewName, componentPresentation);
-
         }
 
         [HandleError]

--- a/dotnet/DD4T.Mvc/Html/IComponentPresentationRenderer.cs
+++ b/dotnet/DD4T.Mvc/Html/IComponentPresentationRenderer.cs
@@ -6,5 +6,6 @@ namespace DD4T.Mvc.Html
     public interface IComponentPresentationRenderer
     {
         MvcHtmlString ComponentPresentations(IPage tridionPage, HtmlHelper htmlHelper, string[] includeComponentTemplate, string includeSchema);
+        string GetComponentTemplateView(IComponentTemplate componentTemplate);
     }
 }


### PR DESCRIPTION
Should solve https://github.com/dd4t/dynamic-delivery-4-tridion/issues/16

The TridionControllerBase has business rule to resolve a view, even though no/empty metadata field 'view' is present. This resolving is not implemented in the RenderComponentPresentationsByView logic. 

Below code has moved the business logic to the ComponentPresentationRenderer helper class. Both the controller and the renderer will use this same function to resolve a view name from the ComponentTemplate.

Solution can be tested by calling 'RenderComponentPresentationsByView' on CP's with a CT that has no metadata fields. 
