### PR TITLE
CultureInfo.InvariantCulture in DateTime ToString

### DIFF
--- a/dotnet/DD4T.Providers.SDLTridion2011/ExtendedQueryParameters.cs
+++ b/dotnet/DD4T.Providers.SDLTridion2011/ExtendedQueryParameters.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using DD4T.Providers.SDLTridion2011;
 using Tridion.ContentDelivery.DynamicContent.Query;
@@ -68,7 +69,7 @@ namespace DD4T.ContentModel.Factories
             //PublicationCriteria publicationAndLastPublishedDateCriteria = new PublicationCriteria(PublicationId);
             PublicationCriteria publicationAndLastPublishedDateCriteria = new PublicationCriteria(PublicationId);
             //format DateTime // 00:00:00.000
-            ItemLastPublishedDateCriteria dateLastPublished = new ItemLastPublishedDateCriteria(lastPublishedDate.ToString("yyyy-MM-dd HH:mm:ss.fff"), Criteria.GreaterThanOrEqual);
+            ItemLastPublishedDateCriteria dateLastPublished = new ItemLastPublishedDateCriteria(lastPublishedDate.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture), Criteria.GreaterThanOrEqual);
             //publicationAndLastPublishedDateCriteria.AddCriteria(dateLastPublished);
 
             Criteria basedOnSchemaAndInPublication;
@@ -108,7 +109,7 @@ namespace DD4T.ContentModel.Factories
                     {
                         case "DateTime":
                             DateTime tempDate = (DateTime)queryItem.MetaValue;
-                            metaCriteria = new CustomMetaValueCriteria(metaField, tempDate.ToString("yyyy-MM-dd HH:mm:ss.fff"), "yyyy-MM-dd HH:mm:ss.SSS", metaOperator);
+                            metaCriteria = new CustomMetaValueCriteria(metaField, tempDate.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture), "yyyy-MM-dd HH:mm:ss.SSS", metaOperator);
                             break;
                         case "Float":
                             metaCriteria = new CustomMetaValueCriteria(metaField, (float)queryItem.MetaValue, metaOperator);

--- a/dotnet/DD4T.Providers.SDLTridion2011sp1/ExtendedQueryParameters.cs
+++ b/dotnet/DD4T.Providers.SDLTridion2011sp1/ExtendedQueryParameters.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Tridion.ContentDelivery.DynamicContent.Query;
 using DD4T.ContentModel;
@@ -68,7 +69,7 @@ namespace DD4T.Providers.SDLTridion2011sp1
             //PublicationCriteria publicationAndLastPublishedDateCriteria = new PublicationCriteria(PublicationId);
             PublicationCriteria publicationAndLastPublishedDateCriteria = new PublicationCriteria(PublicationId);
             //format DateTime // 00:00:00.000
-            ItemLastPublishedDateCriteria dateLastPublished = new ItemLastPublishedDateCriteria(lastPublishedDate.ToString("yyyy-MM-dd HH:mm:ss.fff"), Criteria.GreaterThanOrEqual);
+            ItemLastPublishedDateCriteria dateLastPublished = new ItemLastPublishedDateCriteria(lastPublishedDate.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture), Criteria.GreaterThanOrEqual);
             //publicationAndLastPublishedDateCriteria.AddCriteria(dateLastPublished);
 
             Criteria basedOnSchemaAndInPublication;
@@ -108,7 +109,7 @@ namespace DD4T.Providers.SDLTridion2011sp1
                     {
                         case "DateTime":
                             DateTime tempDate = (DateTime)queryItem.MetaValue;
-                            metaCriteria = new CustomMetaValueCriteria(metaField, tempDate.ToString("yyyy-MM-dd HH:mm:ss.fff"), "yyyy-MM-dd HH:mm:ss.SSS", metaOperator);
+                            metaCriteria = new CustomMetaValueCriteria(metaField, tempDate.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture), "yyyy-MM-dd HH:mm:ss.SSS", metaOperator);
                             break;
                         case "Float":
                             metaCriteria = new CustomMetaValueCriteria(metaField, (float)queryItem.MetaValue, metaOperator);

--- a/dotnet/DD4T.Providers.SDLTridion2013/ExtendedQueryParameters.cs
+++ b/dotnet/DD4T.Providers.SDLTridion2013/ExtendedQueryParameters.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Tridion.ContentDelivery.DynamicContent.Query;
 using DD4T.ContentModel;
@@ -69,7 +70,7 @@ namespace DD4T.Providers.SDLTridion2013
             //PublicationCriteria publicationAndLastPublishedDateCriteria = new PublicationCriteria(PublicationId);
             PublicationCriteria publicationAndLastPublishedDateCriteria = new PublicationCriteria(PublicationId);
             //format DateTime // 00:00:00.000
-            ItemLastPublishedDateCriteria dateLastPublished = new ItemLastPublishedDateCriteria(lastPublishedDate.ToString("yyyy-MM-dd HH:mm:ss.fff"), Criteria.GreaterThanOrEqual);
+            ItemLastPublishedDateCriteria dateLastPublished = new ItemLastPublishedDateCriteria(lastPublishedDate.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture), Criteria.GreaterThanOrEqual);
             //publicationAndLastPublishedDateCriteria.AddCriteria(dateLastPublished);
 
             Criteria basedOnSchemaAndInPublication;
@@ -109,7 +110,7 @@ namespace DD4T.Providers.SDLTridion2013
                     {
                         case "DateTime":
                             DateTime tempDate = (DateTime)queryItem.MetaValue;
-                            metaCriteria = new CustomMetaValueCriteria(metaField, tempDate.ToString("yyyy-MM-dd HH:mm:ss.fff"), "yyyy-MM-dd HH:mm:ss.SSS", metaOperator);
+                            metaCriteria = new CustomMetaValueCriteria(metaField, tempDate.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture), "yyyy-MM-dd HH:mm:ss.SSS", metaOperator);
                             break;
                         case "Float":
                             metaCriteria = new CustomMetaValueCriteria(metaField, (float)queryItem.MetaValue, metaOperator);

--- a/dotnet/DD4T.Providers.SDLTridion2013sp1/ExtendedQueryParameters.cs
+++ b/dotnet/DD4T.Providers.SDLTridion2013sp1/ExtendedQueryParameters.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Tridion.ContentDelivery.DynamicContent.Query;
 using DD4T.ContentModel;
@@ -69,7 +70,7 @@ namespace DD4T.Providers.SDLTridion2013sp1
             //PublicationCriteria publicationAndLastPublishedDateCriteria = new PublicationCriteria(PublicationId);
             PublicationCriteria publicationAndLastPublishedDateCriteria = new PublicationCriteria(PublicationId);
             //format DateTime // 00:00:00.000
-            ItemLastPublishedDateCriteria dateLastPublished = new ItemLastPublishedDateCriteria(lastPublishedDate.ToString("yyyy-MM-dd HH:mm:ss.fff"), Criteria.GreaterThanOrEqual);
+            ItemLastPublishedDateCriteria dateLastPublished = new ItemLastPublishedDateCriteria(lastPublishedDate.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture), Criteria.GreaterThanOrEqual);
             //publicationAndLastPublishedDateCriteria.AddCriteria(dateLastPublished);
 
             Criteria basedOnSchemaAndInPublication;
@@ -109,7 +110,7 @@ namespace DD4T.Providers.SDLTridion2013sp1
                     {
                         case "DateTime":
                             DateTime tempDate = (DateTime)queryItem.MetaValue;
-                            metaCriteria = new CustomMetaValueCriteria(metaField, tempDate.ToString("yyyy-MM-dd HH:mm:ss.fff"), "yyyy-MM-dd HH:mm:ss.SSS", metaOperator);
+                            metaCriteria = new CustomMetaValueCriteria(metaField, tempDate.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture), "yyyy-MM-dd HH:mm:ss.SSS", metaOperator);
                             break;
                         case "Float":
                             metaCriteria = new CustomMetaValueCriteria(metaField, (float)queryItem.MetaValue, metaOperator);


### PR DESCRIPTION
So that no matter what culture is set in the browser, it uses the invariant culture and e.g. doesn't throw an exception when date is out of range for another calendar.
